### PR TITLE
Update log4j to 2.16.0

### DIFF
--- a/microservices-demo/src/couponservice/build.gradle
+++ b/microservices-demo/src/couponservice/build.gradle
@@ -57,7 +57,7 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.11.1",
+                "org.apache.logging.log4j:log4j-core:2.16.0",
                 "javax.annotation:javax.annotation-api:1.3.2"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",


### PR DESCRIPTION
Update log4j from 2.11.1 to 2.16.0 to avoid Update log4j to avoid the critical vulnerability.